### PR TITLE
add gcp path constructor

### DIFF
--- a/bmon/settings.py
+++ b/bmon/settings.py
@@ -48,7 +48,7 @@ BITCOIND_LOG_PATH = os.environ.get('BMON_BITCOIND_LOG_PATH')
 
 # GCP credentials for uploading mempool activity.
 CHAINCODE_GCP_CRED_PATH = os.environ.get('CHAINCODE_GCP_CRED_PATH')
-CHAINCODE_GCP_BUCKET = 'bmon-mempool-log-uploads'
+CHAINCODE_GCP_BUCKET = 'mempool-event-logs'
 
 # For testing
 LOCALHOST_AUTH_TOKEN = '4396049cdfe946f88ec63da115cbcfcf'


### PR DESCRIPTION
add a method for storing mempool log files by day in gcs. this method takes the timestamp from the filename and returns a gcs path.

this ensures we can do daily partitions on the GCP side, which makes dealing with the files much easier and cost-effective. note: this isn't perfect as it is storing files by the timestamp of when the bmon file was created and shipped, not the mempool timestamps. this will be an issue if we enable backfilling in bmon, but i think it can be addressed as a separate pull request when/if backfilling is added.

also changes the default bucket to `mempool-event-logs`

closes #9