### PR TITLE
use avro timestamp-micros logicaltype

### DIFF
--- a/bmon/models.py
+++ b/bmon/models.py
@@ -338,7 +338,7 @@ mempool_activity_avro_schema = fastavro.parse_schema(
         "fields": [
             {"name": "event_type", "type": mempool_event_type_enum},
             {"name": "host", "type": "string"},
-            {"name": "timestamp", "type": "string"},
+            {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-micros"}},
             {"name": "txhash", "type": "string"},
             {"name": "peer_num", "type": ["null", "int"]},
             {"name": "pool_size_txns", "type": ["null", "int"]},
@@ -415,7 +415,7 @@ class MempoolAccept(models.Model):
         return {
             "event_type": "mempool_accept",
             "host": self.host,
-            "timestamp": self.timestamp.isoformat(),
+            "timestamp": self.timestamp,
             "txhash": self.txhash,
             "pool_size_txns": self.pool_size_txns,
             "pool_size_kb": self.pool_size_kb,

--- a/bmon/test_logparse.py
+++ b/bmon/test_logparse.py
@@ -78,6 +78,7 @@ def test_mempool_accept():
     assert got
     assert got.peer_num == 11
     assert got.txhash == "fa4f08dfe610593b505ca5cd8b2ba061ea15a4c480a63dd75b00e2eaddf9b42b"
+    assert isinstance(got.timestamp, datetime.datetime)
     assert got.timestamp == logparse.get_time("2022-10-17T17:57:43.861480Z")
     assert got.pool_size_kb == 25560
     assert got.pool_size_txns == 11848


### PR DESCRIPTION
this ensures that avro binaries store timestamps as the correct type, which then allows the type to be automatically inferred when loading in bigquery which avoids an expensive conversion in the queries.

closes #8