### PR TITLE
fix gcp path

### DIFF
--- a/bmon/bitcoind_tasks.py
+++ b/bmon/bitcoind_tasks.py
@@ -266,7 +266,7 @@ def queue_mempool_to_ship():
 def construct_gcp_path_from_datetime_str(dt):
     d = datetime.datetime.fromisoformat(dt).strftime('%Y-%m-%d')
     dt_formatted = dt.replace(':', '-')
-    return f"{settings.CHAINCODE_GCP_BUCKET}/mempool_events/source=bmon/dt={d}/{settings.HOSTNAME}.{dt_formatted}.avro"
+    return f"mempool_events/source=bmon/dt={d}/{settings.HOSTNAME}.{dt_formatted}.avro"
 
 
 @mempool_q.task()


### PR DESCRIPTION
since we already set the top level bucket when calling the client, we dont need to include it in the target. if we do, we end up with something like \<bucket\>/\<bucket\>/\<path\>, but we want something like \<bucket\>/\<path\>